### PR TITLE
Fix ow manifest not resetting between runs

### DIFF
--- a/dso/act_builder/services/ow/ow_manifest.py
+++ b/dso/act_builder/services/ow/ow_manifest.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Optional
 
 from pydantic import BaseModel
 
@@ -25,12 +25,12 @@ class OwManifestBuilder(OwFileBuilder):
         self,
         act: ActFRBR,
         doel: DoelFRBR,
-        manifest: List[OwManifestBestand] = [],
+        manifest: Optional[List[OwManifestBestand]] = None,
     ):
         super().__init__()
         self._act = act
         self._doel = doel
-        self._manifest = manifest
+        self._manifest = manifest if manifest is not None else []
 
     def add_manifest_item(self, file_name: str, object_types: List[str]) -> None:
         manifest_entry = OwManifestBestand(naam=file_name, objecttypes=object_types)


### PR DESCRIPTION
Dit zorgde ervoor dat bestanden dubbel in de manifest-ow kwamen

```
<?xml version='1.0' encoding='utf-8'?>
<Aanleveringen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.geostandaarden.nl/bestanden-ow/manifest-ow" xsi:schemaLocation="http://www.geostandaarden.nl/bestanden-ow/manifest-ow https://register.geostandaarden.nl/xmlschema/tpod/v2.0.0/bestanden-ow/generiek/manifest-ow.xsd">
  <domein>omgevingswet</domein>
  <Aanlevering>
    <WorkIDRegeling>/akn/nl/act/pv28/2024/programma-1</WorkIDRegeling>
    <DoelID>/join/id/proces/pv28/2024/instelling-programma-1-2</DoelID>
    <Bestand>
      <naam>owLocaties.xml</naam>
      <objecttype>Gebied</objecttype>
      <objecttype>Gebiedengroep</objecttype>
    </Bestand>
    <Bestand>
      <naam>owDivisies.xml</naam>
      <objecttype>Tekstdeel</objecttype>
      <objecttype>Divisietekst</objecttype>
    </Bestand>
    <Bestand>
      <naam>owLocaties.xml</naam>
      <objecttype>Gebied</objecttype>
      <objecttype>Gebiedengroep</objecttype>
    </Bestand>
    <Bestand>
      <naam>owDivisies.xml</naam>
      <objecttype>Tekstdeel</objecttype>
      <objecttype>Divisietekst</objecttype>
    </Bestand>
  </Aanlevering>
</Aanleveringen>
```

Meer info in dit artikel; https://docs.python-guide.org/writing/gotchas/#mutable-default-arguments