### PR TITLE
chore: update dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,16 +27,16 @@ generate:
 	@python -m dso.cmds generate $(MAIN_FILE) $(OUTPUT_DIR)
 
 pip-sync:
-	pip install -U pip pip-tools
+	pip install -U "pip<26.2" pip pip-tools
 	pip-sync requirements.txt requirements-dev.txt
 
 pip-compile:
-	pip install -U pip pip-tools
+	pip install -U "pip<26.2" pip pip-tools
 	pip-compile requirements.in
 	pip-compile requirements-dev.in
 
 pip-upgrade:
-	pip install -U pip pip-tools
+	pip install -U "pip<26.2" pip pip-tools
 	pip-compile --upgrade requirements.in
 	pip-compile --upgrade requirements-dev.in
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -12,8 +12,6 @@ bandit==1.9.4
     # via -r requirements-dev.in
 debugpy==1.8.21
     # via -r requirements-dev.in
-decorator==5.3.1
-    # via ipython
 devtools==0.12.2
     # via -r requirements-dev.in
 executing==2.2.1
@@ -22,7 +20,7 @@ executing==2.2.1
     #   stack-data
 iniconfig==2.3.0
     # via pytest
-ipython==9.15.0
+ipython==9.16.1
     # via -r requirements-dev.in
 ipython-pygments-lexers==1.1.1
     # via ipython
@@ -34,7 +32,7 @@ matplotlib-inline==0.2.2
     # via ipython
 mdurl==0.1.2
     # via markdown-it-py
-packaging==26.2
+packaging==26.3
     # via pytest
 parso==0.8.7
     # via jedi
@@ -42,7 +40,7 @@ pexpect==4.9.0
     # via ipython
 pluggy==1.6.0
     # via pytest
-prompt-toolkit==3.0.52
+prompt-toolkit==3.0.53
     # via ipython
 psutil==7.2.2
     # via ipython
@@ -63,7 +61,7 @@ pyyaml==6.0.3
     # via bandit
 rich==15.0.0
     # via bandit
-ruff==0.15.20
+ruff==0.16.2
     # via -r requirements-dev.in
 six==1.17.0
     # via asttokens
@@ -71,7 +69,7 @@ stack-data==0.6.3
     # via ipython
 stevedore==5.9.0
     # via bandit
-traitlets==5.15.1
+traitlets==5.16.1
     # via
     #   ipython
     #   matplotlib-inline

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,15 +4,15 @@
 #
 #    pip-compile requirements.in
 #
-annotated-types==0.7.0
+annotated-types==0.8.0
     # via pydantic
 beautifulsoup4==4.15.0
     # via -r requirements.in
-certifi==2026.6.17
+certifi==2026.7.22
     # via
     #   pyproj
     #   requests
-charset-normalizer==3.4.7
+charset-normalizer==3.4.9
     # via requests
 click==8.4.2
     # via -r requirements.in
@@ -26,13 +26,13 @@ markupsafe==3.0.3
     # via
     #   -r requirements.in
     #   jinja2
-numpy==2.5.0
+numpy==2.5.2
     # via shapely
-packaging==26.2
+packaging==26.3
     # via -r requirements.in
 pathspec==1.1.1
     # via -r requirements.in
-platformdirs==4.10.0
+platformdirs==4.11.1
     # via -r requirements.in
 pydantic==2.13.4
     # via -r requirements.in
@@ -52,7 +52,7 @@ roman==5.2
     # via -r requirements.in
 shapely==2.1.2
     # via -r requirements.in
-soupsieve==2.8.4
+soupsieve==2.9.2
     # via beautifulsoup4
 text-unidecode==1.3
     # via python-slugify
@@ -65,7 +65,7 @@ typing-extensions==4.16.0
     #   pydantic
     #   pydantic-core
     #   typing-inspection
-typing-inspection==0.4.2
+typing-inspection==0.4.3
     # via pydantic
 urllib3==2.7.0
     # via requests


### PR DESCRIPTION
pip 26.2 removed the private stdlib_pkgs attribute that pip-tools relies on internally, and pip-tools hasn't caught up yet